### PR TITLE
Add redirect for fec-proxy app urls

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 256M
     routes:
       - route: fec-dev-cms.app.cloud.gov
+      - route: fec-dev-proxy.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 256M
     routes:
       - route: fec-prod-cms.app.cloud.gov
+      - route: fec-prod-proxy.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 256M
     routes:
       - route: fec-stage-cms.app.cloud.gov
+      - route: fec-stage-proxy.app.cloud.gov
     services:
       - fec-creds-stage
     env:


### PR DESCRIPTION
- Requires Wagtail UAA changes to be in place in dev space (✅ )

Partial resolution for https://github.com/fecgov/fec-accounts/issues/322

See https://github.com/fecgov/fec-accounts/issues/289 for a diagram of how this will all work once it's complete

- Add redirect from proxy app route to CDN route (example: fec-dev-proxy.app.cloud.gov  ➡️ dev.fec.gov)

<img width="850" alt="Screen Shot 2020-11-18 at 6 17 44 PM" src="https://user-images.githubusercontent.com/31420082/99599942-6041f500-29ca-11eb-88d8-46a4bcf8191b.png">


### Reviewers
At least two approvals, please

### How to test
- Make a copy of this branch and name it `release/<your_branch_name>` and/or add `|| ${branch} == "<your_branch_name>" ]]` to this line: https://github.com/fecgov/fec-proxy/blob/ed7387c8ac1ee68bf42b02610c9b1fcb8560406a/bin/cf_deploy.sh#L14
So it reads:
```
if [[ ${branch} == "develop" || ${branch} == "<your_branch_name>" ]]; then
```
- Push up your branch
- Your branch gets deployed to the `stage` space (or `dev` if you changed the dev rules above)
- Go to fec-stage-proxy.app.cloud.gov or fec-dev-proxy.app.cloud.gov (depending on which you chose)
- About 50% of the time, it will redirect to the CDN route (ie dev.fec.gov or stage.fec.gov) and the rest of the time, the application itself will load without redirecting.
- ❓ Why doesn't it work every time? This is because the CMS app and this redirect app are sharing this route (check this out with `cf apps` and see they share a route), so traffic will get routed to both apps. With this approach, we have a zero-downtime approach. If we remove the public route from the CMS (https://github.com/fecgov/fec-accounts/issues/318) before this redirect app is deployed, all the bookmarked and google search result URLs will 404.


