### PR TITLE
Add redirect for eregs app urls

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-dev-cms.app.cloud.gov
       - route: fec-dev-proxy.app.cloud.gov
+      - route: fec-dev-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-prod-cms.app.cloud.gov
       - route: fec-prod-proxy.app.cloud.gov
+      - route: fec-prod-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-stage-cms.app.cloud.gov
       - route: fec-stage-proxy.app.cloud.gov
+      - route: fec-stage-eregs.app.cloud.gov
     services:
       - fec-creds-stage
     env:


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-accounts/issues/328

Part of https://github.com/fecgov/fec-accounts/issues/325

- Add eregs app urls to CDN redirect app

![Screen Shot 2020-11-20 at 12.08.51 PM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/b4ba994f-6aae-4784-a116-9ff20e40b197)

### Reviewers
At least two approvals, please

### How to test
- Make a copy of this branch and add `|| ${branch} == "<your_branch_name>" ]]` to this line: https://github.com/fecgov/fec-proxy/blob/ed7387c8ac1ee68bf42b02610c9b1fcb8560406a/bin/cf_deploy.sh#L14
So it reads:
```
if [[ ${branch} == "develop" || ${branch} == "<your_branch_name>" ]]; then
```
- Push up your branch
- Your branch gets deployed to the `dev` space
- Go to fec-dev-eregs.app.cloud.gov 
- About 50% of the time, it will redirect to the CDN route (ie dev.fec.gov/regulations and the rest of the time, the application itself will load without redirecting (thought it's a server error due to https://github.com/fecgov/fec-eregs/issues/500 bug)
- ❓ Why doesn't it work every time? This is because the eregs app and this redirect app are sharing this route (check this out with `cf apps` and see they share a route), so traffic will get routed to both apps. With this approach, we have a zero-downtime approach. If we remove the public route from the eregs (https://github.com/fecgov/fec-accounts/issues/318) before this redirect app is deployed, all the bookmarked and google search result URLs will 404.