### PR TITLE
 Add eregs app urls to proxy redirect 

### DIFF
--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -11,7 +11,7 @@ org=${2}
 branch=${3}
 
 # Get the space that corresponds with the branch name
-if [[ ${branch} == "develop" || ${branch} == "feature/328-add-eregs-app-urls-proxy-redirect" ]]; then
+if [[ ${branch} == "develop" ]]; then
     echo "Branch is develop, deploying to dev space"
     space="dev"
 elif [[ ${branch} == release* ]]; then

--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -11,7 +11,7 @@ org=${2}
 branch=${3}
 
 # Get the space that corresponds with the branch name
-if [[ ${branch} == "develop" ]]; then
+if [[ ${branch} == "develop" || ${branch} == "feature/328-add-eregs-app-urls-proxy-redirect" ]]; then
     echo "Branch is develop, deploying to dev space"
     space="dev"
 elif [[ ${branch} == release* ]]; then

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-dev-cms.app.cloud.gov
       - route: fec-dev-proxy.app.cloud.gov
+      - route: fec-dev-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-prod-cms.app.cloud.gov
       - route: fec-prod-proxy.app.cloud.gov
+      - route: fec-prod-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
       - staticfile_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -7,6 +7,7 @@ applications:
     routes:
       - route: fec-stage-cms.app.cloud.gov
       - route: fec-stage-proxy.app.cloud.gov
+      - route: fec-stage-eregs.app.cloud.gov
     services:
       - fec-creds-stage
     env:


### PR DESCRIPTION
Resolves #https://github.com/fecgov/fec-accounts/issues/328

### Reviewers
At least two approvals required.

### How to test
- Make a copy of this branch and name it `release/<your_branch_name>` and/or add `|| ${branch} == "<your_branch_name>" ]]` to this line: https://github.com/fecgov/fec-proxy/blob/ed7387c8ac1ee68bf42b02610c9b1fcb8560406a/bin/cf_deploy.sh#L14
So it reads:
```
if [[ ${branch} == "develop" || ${branch} == "<your_branch_name>" ]]; then
```
- Push up your branch to dev or stage space
- Your branch gets deployed to the `stage` space (or `dev` if you changed the dev rules above)
- Go to fec-dev-eregs.app.cloud.gov or fec-stage-eregs.app.cloud.gov(depending on which you chose) the eregs app url  will now redirect to  EREGS app on dev.fec.gov or stage.fec.gov.
- Go to fec-dev-eregs.app.cloud.gov/regulations or fec-stage-eregs.app.cloud.gov/regulations (depending on which you chose) the eregs app url  will now redirect to  EREGS app on dev.fec.gov/regulations or stage.fec.gov/regulations.

