### PR TITLE
Move to nginx buildpack, set DNS TTL to 1 second

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,1 +1,0 @@
-# Must be included to deploy the staticfile buildpack

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -10,7 +10,7 @@ applications:
       - route: fec-dev-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
-      - staticfile_buildpack
+      - nginx_buildpack
     services:
       - fec-creds-dev
     env:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -10,7 +10,7 @@ applications:
       - route: fec-prod-eregs.app.cloud.gov
     stack: cflinuxfs3
     buildpacks:
-      - staticfile_buildpack
+      - nginx_buildpack
     services:
       - fec-creds-prod
     env:

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -8,6 +8,9 @@ applications:
       - route: fec-stage-cms.app.cloud.gov
       - route: fec-stage-proxy.app.cloud.gov
       - route: fec-stage-eregs.app.cloud.gov
+    stack: cflinuxfs3
+    buildpacks:
+      - nginx_buildpack
     services:
       - fec-creds-stage
     env:

--- a/mime.types
+++ b/mime.types
@@ -1,28 +1,29 @@
 types {
-  text/html                             html htm shtml;
-  text/css                              css;
-  text/xml                              xml rss;
-
-  image/gif                             gif;
-  image/jpeg                            jpeg jpg;
-
-  application/x-javascript              js;
-
-  text/plain                            txt;
-  text/x-component                      htc;
-  text/mathml                           mml;
-
-  image/png                             png;
-  image/x-icon                          ico;
-  image/x-jng                           jng;
-  image/vnd.wap.wbmp                    wbmp;
-
+  application/atom+xml                  atom;
   application/java-archive              jar war ear;
+  application/json                      json;
   application/mac-binhex40              hqx;
+  application/msword                    doc;
+  application/octet-stream              bin exe dll;
+  application/octet-stream              deb;
+  application/octet-stream              dmg;
+  application/octet-stream              eot;
+  application/octet-stream              iso img;
+  application/octet-stream              msi msp msm;
   application/pdf                       pdf;
+  application/postscript                ps eps ai;
+  application/rss+xml                   rss;
+  application/rtf                       rtf;
+  application/vnd.google-earth.kml+xml  kml;
+  application/vnd.google-earth.kmz      kmz;
+  application/vnd.ms-excel              xls;
+  application/vnd.ms-powerpoint         ppt;
+  application/vnd.wap.wmlc              wmlc;
+  application/x-7z-compressed           7z;
   application/x-cocoa                   cco;
   application/x-java-archive-diff       jardiff;
   application/x-java-jnlp-file          jnlp;
+  application/x-javascript              js;
   application/x-makeself                run;
   application/x-perl                    pl pm;
   application/x-pilot                   prc pdb;
@@ -34,22 +35,50 @@ types {
   application/x-tcl                     tcl tk;
   application/x-x509-ca-cert            der pem crt;
   application/x-xpinstall               xpi;
+  application/xhtml+xml                 xhtml;
   application/zip                       zip;
-  application/octet-stream              deb;
-  application/octet-stream              bin exe dll;
-  application/octet-stream              dmg;
-  application/octet-stream              eot;
-  application/octet-stream              iso img;
-  application/octet-stream              msi msp msm;
 
+  audio/midi                            mid midi kar;
   audio/mpeg                            mp3;
+  audio/ogg                             ogg;
+  audio/x-m4a                           m4a;
   audio/x-realaudio                     ra;
 
+  font/otf                              otf;
+  font/ttf                              ttf;
+  font/woff                             woff;
+  font/woff2                            woff2;
+
+  image/gif                             gif;
+  image/jpeg                            jpeg jpg;
+  image/png                             png;
+  image/svg+xml                         svg svgz;
+  image/tiff                            tif tiff;
+  image/vnd.wap.wbmp                    wbmp;
+  image/webp                            webp;
+  image/x-icon                          ico;
+  image/x-jng                           jng;
+  image/x-ms-bmp                        bmp;
+
+  text/cache-manifest                   manifest;
+  text/css                              css;
+  text/html                             html htm shtml;
+  text/mathml                           mml;
+  text/plain                            txt;
+  text/vnd.sun.j2me.app-descriptor      jad;
+  text/vnd.wap.wml                      wml;
+  text/x-component                      htc;
+  text/xml                              xml;
+
+  video/3gpp                            3gpp 3gp;
+  video/mp4                             mp4;
   video/mpeg                            mpeg mpg;
   video/quicktime                       mov;
+  video/webm                            webm;
   video/x-flv                           flv;
-  video/x-msvideo                       avi;
-  video/x-ms-wmv                        wmv;
-  video/x-ms-asf                        asx asf;
+  video/x-m4v                           m4v;
   video/x-mng                           mng;
+  video/x-ms-asf                        asx asf;
+  video/x-ms-wmv                        wmv;
+  video/x-msvideo                       avi;
 }

--- a/mime.types
+++ b/mime.types
@@ -1,0 +1,55 @@
+types {
+  text/html                             html htm shtml;
+  text/css                              css;
+  text/xml                              xml rss;
+
+  image/gif                             gif;
+  image/jpeg                            jpeg jpg;
+
+  application/x-javascript              js;
+
+  text/plain                            txt;
+  text/x-component                      htc;
+  text/mathml                           mml;
+
+  image/png                             png;
+  image/x-icon                          ico;
+  image/x-jng                           jng;
+  image/vnd.wap.wbmp                    wbmp;
+
+  application/java-archive              jar war ear;
+  application/mac-binhex40              hqx;
+  application/pdf                       pdf;
+  application/x-cocoa                   cco;
+  application/x-java-archive-diff       jardiff;
+  application/x-java-jnlp-file          jnlp;
+  application/x-makeself                run;
+  application/x-perl                    pl pm;
+  application/x-pilot                   prc pdb;
+  application/x-rar-compressed          rar;
+  application/x-redhat-package-manager  rpm;
+  application/x-sea                     sea;
+  application/x-shockwave-flash         swf;
+  application/x-stuffit                 sit;
+  application/x-tcl                     tcl tk;
+  application/x-x509-ca-cert            der pem crt;
+  application/x-xpinstall               xpi;
+  application/zip                       zip;
+  application/octet-stream              deb;
+  application/octet-stream              bin exe dll;
+  application/octet-stream              dmg;
+  application/octet-stream              eot;
+  application/octet-stream              iso img;
+  application/octet-stream              msi msp msm;
+
+  audio/mpeg                            mp3;
+  audio/x-realaudio                     ra;
+
+  video/mpeg                            mpeg mpg;
+  video/quicktime                       mov;
+  video/x-flv                           flv;
+  video/x-msvideo                       avi;
+  video/x-ms-wmv                        wmv;
+  video/x-ms-asf                        asx asf;
+  video/x-mng                           mng;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,12 +1,12 @@
 worker_processes 1;
 daemon off;
 
-error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+error_log stderr;
 events { worker_connections 1024; }
 
 http {
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
-  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
   include mime.types;
   sendfile on;
@@ -23,31 +23,27 @@ http {
   keepalive_timeout 300;
   proxy_connect_timeout 300;
   proxy_read_timeout 300;
-  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  # Ensure that redirects don't include the internal container PORT - {{port}}
+  port_in_redirect off;
   server_tokens off;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    listen {{port}};
     server_name localhost;
 
     # Restrict IPs
-    include <%= ENV["APP_ROOT"] %>/public/blockips.conf;
-
-    <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
-    auth_basic "Restricted";
-    auth_basic_user_file <%= auth_file %>;
-    <% end %>
+    include blockips.conf;
 
     location ~ / {
-        resolver 8.8.8.8 ipv6=off;
-        set $backend "<%= ENV["CDN_ROUTE"] %>";
+        resolver 8.8.8.8 ipv6=off valid=1s;
+        set $backend "{{env "CDN_ROUTE"}}";
         proxy_pass $backend;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Script-Name "/";
         proxy_set_header X-Forwarded-Proto https;
         add_header Cache-Control "max-age=600";
-        rewrite ^/(.*)$ https://<%= ENV["CDN_ROUTE"] %>/$1 redirect;
+        rewrite ^/(.*)$ https://{{env "CDN_ROUTE"}}/$1 redirect;
     }
 
   }


### PR DESCRIPTION
Resolves #2
- Move to nginx buildpack
- Remove embedded Ruby (`<% example %>`) from configuration file
- Set DNS TTL to 1 second

**How to test**
- [Deploy manually](https://github.com/fecgov/fec-proxy-redirect#deployment) to dev space, make sure fec-dev-cms.app.cloud.gov redirects to dev.fec.gov works
