### PR TITLE
migrate deploy to run in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
 
-      - deploy:
+      - run:
           name: Deploy Proxy
           command: |
             export PATH=$HOME/bin:$PATH


### PR DESCRIPTION
## Summary (required)

A configuration file that uses the deprecated deploy step must be converted, and all instances of the deploy step must be removed, regardless of whether or not [parallelism](https://circleci.com/docs/parallelism-faster-jobs/) is used in the job.

Replace deprecated `deploy` step with `run` in circleci/config.yml 

- Resolves #https://github.com/fecgov/openFEC/issues/5678



### Required reviewers

2 developers

## Impacted areas of the application

-  cms app deployment to cloud space 

## How to test

- Create a test branch off `feature/circleci-migrate-to-run`  and deploy to `dev` space
- On circleci `Deploy Proxy` step,  Proxy-redirect app should deploy to dev space without failures

