### PR TITLE
 [MERGE WITH GITFLOW] Release/public 20240220

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
 
-      - deploy:
+      - run:
           name: Deploy Proxy
           command: |
             export PATH=$HOME/bin:$PATH


### PR DESCRIPTION
This is for the sprint PI 24.1 release.
@fec-jli will deploy this.