### PR TITLE
upgrade cf cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.9.0" | tar xzv -C $HOME/bin
 
       - run:
           name: Deploy Proxy

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The proxy follows [other projects](https://github.com/fecgov/openFEC#creating-a-
 
 Manual deployment is an option if there are issues with CircleCI or you want more granular control of the process.
 
-Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
+Before you start, make sure you have version 8 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 
 When you're ready to deploy any changes, make sure you are on the `master` branch and have done a `git pull` so that all changes are pulled down.  Now run the following commands, where `<space>` is the desired space you'd like to deploy to (`dev`, `stage`, or `prod`):
 


### PR DESCRIPTION
## Summary 
The Cloud.gov v2 API for Cloud Foundry is reaching its end-of-life. CF CLI versions 6 and 7 still rely on Cloud Foundry API v2 and will no longer work in coming months with foundations that have disabled it. However, CF CLI v8 no longer uses Cloud Foundry API v2. For more details, refer to this [link](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#impact-and-consequences).

1. circleci/config.yml, is upgraded to CF CLI v8.9.0. This version supports Cloud Foundry API v3. Deploying to a cloud.gov space should work smoothly with this update

## Resolves # https://github.com/fecgov/openFEC/issues/6110

### Required reviewers

1 developer

## Impacted areas of the application

- install cf cli script
- deploy proxy (to cloud.gov space)


## Screenshots
**Before:**
[cf cli v7.7.15 circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-proxy-redirect/56/workflows/6871f3a8-9091-4736-b9bd-fffa8a201a6b/jobs/81):

<img width="1131" alt="Screenshot 2025-01-29 at 3 57 15 PM" src="https://github.com/user-attachments/assets/a98c1944-50d9-4f75-a172-c5851f078b12" />

**After:**
[cf cli v8.9.0. circleci build]():

<img width="1135" alt="Screenshot 2025-01-29 at 3 51 07 PM" src="https://github.com/user-attachments/assets/cbb5526a-16d0-417a-9fc2-034d5ef888fc" />

## Related PRs

Related PRs against other branches:

- openFEC: https://github.com/fecgov/openFEC/pull/6114
- fec-cms: https://github.com/fecgov/fec-cms/pull/6657
- fec-pattern-library: https://github.com/fecgov/fec-pattern-library/pull/229
- fec-proxy - https://github.com/fecgov/fec-proxy/pull/416

## How to test
 
- Follow [these](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) instructions to install cf CLI v8 on your local terminal or  run: `brew install cloudfoundry/tap/cf-cli@8`
- verify cf cli version: run `cf version`

```
F612211M:~ pkasireddy$ cf version
cf version 8.9.0+c23186c.2024-12-02
```
- login to cloud.gov dev space. use the [manual deployment steps](https://github.com/fecgov/fec-proxy-redirect?tab=readme-ov-file#manual-deployment) to deploy this app from terminal

- Observe the following in terminal: 
- 1. Confirm that fec-proxy-redirect app  is using [Cloud Foundry v3 API](https://v3-apidocs.cloudfoundry.org/version/3.185.0/):

```
API endpoint:   https://api.fr.cloud.gov
API version:    3.185.0
```




